### PR TITLE
Add basic unit tests for proxy utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore Mac DS_Store files
 *.DS_Store
+__pycache__/

--- a/test_valid8proxy.py
+++ b/test_valid8proxy.py
@@ -1,0 +1,26 @@
+import builtins
+import os
+import Valid8Proxy as vp
+
+
+def test_save_proxies_to_file(tmp_path):
+    proxies = ['1.1.1.1:80', '2.2.2.2:8080']
+    file_path = tmp_path / 'out.txt'
+    vp.save_proxies_to_file(proxies, filename=str(file_path))
+    assert file_path.read_text() == '1.1.1.1:80\n2.2.2.2:8080\n'
+
+
+def test_validate_and_print_proxies_respects_limit(monkeypatch):
+    proxies = [f'192.168.0.{i}:80' for i in range(5)]
+    call_count = {'count': 0}
+
+    def fake_is_proxy_working(proxy):
+        call_count['count'] += 1
+        return True
+
+    monkeypatch.setattr(vp, 'is_proxy_working', fake_is_proxy_working)
+    vp.stop_code = False
+    working = vp.validate_and_print_proxies(proxies, print_limit=3)
+    assert len(working) == 3
+    assert set(proxies[:3]) == working
+    assert call_count['count'] == 3


### PR DESCRIPTION
## Summary
- add unit tests verifying `save_proxies_to_file` writes to disk
- test that `validate_and_print_proxies` respects the requested limit
- ignore Python bytecode in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a860c718832b84f4ed84676ab8df